### PR TITLE
Environment files and articles cache defaults

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -62,8 +62,8 @@ export REDIS_TEST_URL="${REDIS_URL}"
 export CACHE_DURATION="+2 minutes"
 
 # Front end site cache configuration, either Redis or File
-export ARTICLES_CACHE_ENGINE="File"
-export ARTICLES_INDEX_CACHE_ENGINE="File"
+#export ARTICLES_CACHE_ENGINE="File"
+#export ARTICLES_INDEX_CACHE_ENGINE="File"
 
 # Queue configuration
 export QUEUE_DEFAULT_URL="${REDIS_URL}"


### PR DESCRIPTION
env() for articles cache has defaults for redis already, phpunit.xml.dist sets to File based, therefore .env doesn't strictly need these exported, but it's good for reference until a section on cache is added to the readme 

# Front end site cache configuration, either Redis or File
#export ARTICLES_CACHE_ENGINE="File"
#export ARTICLES_INDEX_CACHE_ENGINE="File"