### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/matthewdeaves/willow/security/code-scanning/15](https://github.com/matthewdeaves/willow/security/code-scanning/15)

In general, the fix is to add an explicit `permissions:` block limiting `GITHUB_TOKEN` to the least privileges the workflow needs. Since these metrics jobs only check out code, install dependencies, run analysis, and upload artifacts, they only require read access to repository contents; they do not need to write to contents, issues, or pull requests.

The single best fix without changing functionality is to add a workflow‑level `permissions:` block near the top of `.github/workflows/ci.yml`, right after the `name:` or `on:` block, setting `contents: read`. This will apply to all jobs that do not override permissions, including `metrics-duplication` (the job highlighted by CodeQL) and the other metrics jobs shown. None of the shown steps require broader token scopes, so this should be safe. No additional imports or methods are required; it is purely a YAML configuration change within the workflow file.

Concretely, update `.github/workflows/ci.yml` so that after line 2 (the blank line following `name: CI`) you insert:

```yaml
permissions:
  contents: read
```

leaving the rest of the file unchanged. This satisfies CodeQL’s recommendation and ensures the `GITHUB_TOKEN` is scoped appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
